### PR TITLE
[feat] Added proxyAdmin check and roles check scripts

### DIFF
--- a/scripts/1_production_deploy.py
+++ b/scripts/1_production_deploy.py
@@ -40,7 +40,7 @@ def main():
     strategist = registry.get("governance")
     guardian = registry.get("guardian")
     keeper = registry.get("keeper")
-    proxyAdmin = registry.get("proxyAdmin")
+    proxyAdmin = registry.get("proxyAdminTimelock")
 
     assert strategist != AddressZero
     assert guardian != AddressZero

--- a/scripts/2_production_guestlist.py
+++ b/scripts/2_production_guestlist.py
@@ -44,7 +44,7 @@ def main():
     registry = BadgerRegistry.at(REGISTRY)
 
     governance = registry.get("governance")
-    proxyAdmin = registry.get("proxyAdmin")
+    proxyAdmin = registry.get("proxyAdminTimelock")
 
     assert governance != AddressZero
     assert proxyAdmin != AddressZero

--- a/scripts/5_production_proxy_check.py
+++ b/scripts/5_production_proxy_check.py
@@ -1,0 +1,127 @@
+from brownie import network, BadgerRegistry, Controller, SettV3, web3
+from config import REGISTRY
+from helpers.constants import AddressZero
+from rich.console import Console
+
+console = Console()
+
+ADMIN_SLOT = int(
+    0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103
+)
+
+def main():
+    """
+    Checks that the proxyAdmin of all contracts added to the BadgerRegistry match
+    the proxyAdminTimelock address from the same registry. How to run:
+
+    1. Add all keys for the network's registry to the 'keys' array below.
+    
+    2. Add all authors' addresses with vaults added to the registry into the 'authors' array below. 
+
+    3. Run the script and review the console output.
+    """
+
+    console.print("You are using the", network.show_active(), "network")
+
+    # Get production registry
+    registry = BadgerRegistry.at(REGISTRY)
+
+    # Get proxyAdminTimelock address to compare to
+    proxyAdmin = registry.get("proxyAdminTimelock")
+    assert proxyAdmin != AddressZero
+    console.print("[cyan]proxyAdminTimelock:[/cyan]", proxyAdmin)
+
+    # NOTE: Add all existing keys from your network's registry. For example:
+    keys = [
+        "governance",
+        "guardian",
+        "keeper",
+        "controller",
+        "badgerTree",
+        "devGovernancce",
+        "paymentsGovernance",
+        "governanceTimelock",
+        "proxyAdminDev",
+        "rewardsLogger",
+        "keeperAccessControl",
+        "proxyAdminDfdBadger",
+        "dfdBadgerSharedGovernance"
+    ]
+
+    # NOTE: Add all authors from your network registry. For example:
+    authors = [
+        "0xeE8b29AA52dD5fF2559da2C50b1887ADee257556"
+    ]
+
+    check_by_keys(registry, proxyAdmin, keys)
+    check_vaults_and_strategies(registry, proxyAdmin, authors)
+
+
+def check_by_keys(registry, proxyAdmin, keys):
+    console.print("[blue]Checking proxyAdmins by key...[/blue]")
+    # Check the proxyAdmin of the different proxy contracts
+    for key in keys:
+        proxy = registry.get(key)
+        if proxy == AddressZero:
+            console.print(
+                key, ":[red] key doesn't exist on the registry![/red]"
+            )
+            continue
+        check_proxy_admin(proxy, proxyAdmin, key)
+
+
+def check_vaults_and_strategies(registry, proxyAdmin, authors):
+    console.print("[blue]Checking proxyAdmins from vaults and strategies...[/blue]")
+
+    vaultStatus = [0, 1, 2]
+
+    vaults = []
+    strategies = []
+    stratNames = []
+
+    # get vaults by author
+    for author in authors:
+        vaults += registry.getVaults("v1", author)
+        vaults += registry.getVaults("v2", author)
+
+    # Get promoted vaults
+    for status in vaultStatus:
+        vaults += registry.getFilteredProductionVaults("v1", status)
+        vaults += registry.getFilteredProductionVaults("v2", status)
+
+    # Get strategies from vaults and check vaults' proxyAdmins
+    for vault in vaults:
+        vaultContract = SettV3.at(vault)
+        # get Controller
+        controller = Controller.at(vaultContract.controller())
+        strategies.append(controller.strategies(vaultContract.token()))
+        stratNames.append(vaultContract.name().replace("Badger Sett ", "Strategy "))
+        # Check vault proxyAdmin
+        check_proxy_admin(vault, proxyAdmin, vaultContract.name())
+
+
+    for strat in strategies:
+    # Check strategies' proxyAdmin
+        check_proxy_admin(strat, proxyAdmin, stratNames[strategies.index(strat)])
+
+
+def check_proxy_admin(proxy, proxyAdmin, key):
+    # Get proxyAdmin address form the proxy's ADMIN_SLOT 
+    val = web3.eth.getStorageAt(proxy, ADMIN_SLOT).hex()
+    address = "0x" + val[26:66]
+
+    # Check differnt possible scenarios
+    if address == AddressZero:
+        console.print(
+            key, ":[red] admin not found on slot (GnosisSafeProxy?)[/red]"
+        )
+    elif address != proxyAdmin:
+        console.print(
+            key, ":[red] admin is different to proxyAdminTimelock[/red] - ", 
+            address
+        )
+    else:
+        assert address == proxyAdmin
+        console.print(
+            key, ":[green] admin matches proxyAdminTimelock![/green]"
+        )

--- a/scripts/5_production_proxy_check.py
+++ b/scripts/5_production_proxy_check.py
@@ -50,7 +50,7 @@ def main():
 
     # NOTE: Add all authors from your network registry. For example:
     authors = [
-        "0xeE8b29AA52dD5fF2559da2C50b1887ADee257556"
+        "0x1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a"
     ]
 
     check_by_keys(registry, proxyAdmin, keys)

--- a/scripts/6_production_roles_check.py
+++ b/scripts/6_production_roles_check.py
@@ -98,7 +98,7 @@ def check_controller_roles(registry):
 
     controllerAddress = registry.get("controller")
     governance = registry.get("governance")
-    governanceTimelock = #registry.get("governanceTimelock")
+    governanceTimelock = registry.get("governanceTimelock")
 
     assert controllerAddress != AddressZero
     assert governance != AddressZero

--- a/scripts/6_production_roles_check.py
+++ b/scripts/6_production_roles_check.py
@@ -1,0 +1,141 @@
+from brownie import network, BadgerRegistry, Controller, interface, web3
+from config import REGISTRY
+from helpers.constants import AddressZero
+from rich.console import Console
+from tabulate import tabulate
+
+console = Console()
+
+DEFAULT_ADMIN_ROLE = "0x0000000000000000000000000000000000000000000000000000000000000000"
+
+tableHead = ["Role", "MemberCount", "Address"]
+
+def main():
+    """
+    Checks that the proxyAdmin of all conracts added to the BadgerRegistry match
+    the proxyAdminTimelock address on the same registry. How to run:
+
+    1. Add all keys to check paired to the key of the expected DEFAULT_ADMIN_ROLE to the 
+       'keysWithAdmins' array.
+    
+    2. Add an array with all the expected roles belonging to each one of the keyed contracts
+       added on the previous step to the 'roles' array. The index of the key must match the index
+       of its roles array.
+
+    3. Additionally, the script will check that the controller's governance and strategist match
+       the Badger's production configuration addresses.
+
+    4. Run the script and analyze the printed results.
+    """
+
+    console.print("You are using the", network.show_active(), "network")
+
+    # Get production registry
+    registry = BadgerRegistry.at(REGISTRY)
+
+    # NOTE: Add keys to check paired to the key of their expected DEFAULT_ADMIN_ROLE:
+    keysWithAdmins = [
+        ["badgerTree", "governance"],
+        ["BadgerRewardsManager", "governance"],
+        ["rewardsLogger", "governance"],
+        ["guardian", "governance"],
+        ["keeper", "devGovernance"],
+    ]
+
+    # NOTE: Add all the roles related to the keys to check from the previous array. Indexes must match!
+    roles = [
+        ["DEFAULT_ADMIN_ROLE", "ROOT_PROPOSER_ROLE", "ROOT_VALIDATOR_ROLE", "PAUSER_ROLE", "UNPAUSER_ROLE"],
+        ["DEFAULT_ADMIN_ROLE", "SWAPPER_ROLE", "DISTRIBUTOR_ROLE"],
+        ["DEFAULT_ADMIN_ROLE", "MANAGER_ROLE"],
+        ["DEFAULT_ADMIN_ROLE", "APPROVED_ACCOUNT_ROLE"],
+        ["DEFAULT_ADMIN_ROLE", "EARNER_ROLE", "HARVESTER_ROLE", "TENDER_ROLE"],
+    ]
+
+    assert len(keysWithAdmins) == len(roles)
+
+    check_roles(registry, keysWithAdmins, roles)
+    check_controller_roles(registry)
+
+
+def check_roles(registry, keysWithAdmins, roles):
+    for key in keysWithAdmins:
+        console.print("[blue]Checking roles for[/blue]", key[0])
+
+        # Get contract address
+        contract = registry.get(key[0])
+        admin = registry.get(key[1])
+        
+        if contract == AddressZero:
+            console.print("[red]Key not found on registry![/red]")
+            continue
+
+        tableData = []
+
+        accessControl = interface.IAccessControl(contract)
+
+        keyRoles = roles[keysWithAdmins.index(key)]
+        hashes = get_roles_hashes(keyRoles)
+        
+        for role in keyRoles:
+            roleHash = hashes[keyRoles.index(role)]
+            roleMemberCount = accessControl.getRoleMemberCount(roleHash)
+            if roleMemberCount == 0:
+                tableData.append([role, "-", "No Addresses found for this role"])
+            else:
+                for memberNumber in range(roleMemberCount):
+                    memberAddress = accessControl.getRoleMember(roleHash, memberNumber)
+                    if role == "DEFAULT_ADMIN_ROLE":
+                        if memberAddress == admin:
+                            console.print("[green]DEFAULT_ADMIN_ROLE matches[/green]", key[1], admin)
+                        else: 
+                            console.print("[red]DEFAULT_ADMIN_ROLE doesn't match[/red]", key[1], admin)
+                    tableData.append([role, memberNumber, memberAddress])
+
+        print(tabulate(tableData, tableHead, tablefmt="grid"))
+
+def check_controller_roles(registry):
+    console.print("[blue]Checking roles for Controller...[/blue]")
+
+    controllerAddress = registry.get("controller")
+    governance = registry.get("governance")
+    governanceTimelock = #registry.get("governanceTimelock")
+
+    assert controllerAddress != AddressZero
+    assert governance != AddressZero
+    assert governanceTimelock != AddressZero
+
+    controller = Controller.at(controllerAddress)
+
+    # Check governance
+    if controller.governance() == governanceTimelock:
+        console.print(
+            "[green]controller.governance() matches governanceTimelock -[/green]", 
+            governanceTimelock
+        )
+    else: 
+        console.print(
+            "[red]controller.governance() doesn't match governanceTimelock -[/red]", 
+            controller.governance()
+        )
+    # Check strategist
+    if controller.strategist() == governance:
+        console.print(
+            "[green]controller.strategist() matches governance -[/green]", 
+            governance
+        )
+    else: 
+        console.print(
+            "[red]controller.strategist() doesn't match governance -[/red]", 
+            controller.strategist()
+        )
+
+def get_roles_hashes(roles):
+    hashes = []
+    for role in roles:
+        if role == "DEFAULT_ADMIN_ROLE":
+            hashes.append(DEFAULT_ADMIN_ROLE)
+        else:
+            hashes.append(web3.keccak(text=role).hex())
+
+    return hashes
+


### PR DESCRIPTION
- Added a script to check that the proxyAdmin of all contracts added to the BadgerRegistry match the proxyAdminTimelock address from the same registry.
- Changed the default proxyAdmin upon deployments to be the proxyAdminTimelock (deploy and guestlist scripts).

Example Console output:
![image](https://user-images.githubusercontent.com/25463788/130649058-79c0f6a0-84fe-482b-aa1e-adc48cab4d03.png)
